### PR TITLE
Feature/v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,22 @@
 
 投稿力の変わらないただ一つのBlueskyクライアント。そう、まぜそば大陸ならね。
 
-Out of respect for [ラーメン大陸](https://www16.atpages.jp/nigore/soft/).
+Out of respect for [ラーメン大陸](https://forest.watch.impress.co.jp/docs/news/559014.html).
 
 ## About
+
+### 使い方
+
+初回起動すると「設定ファイルが未設定だよ」みたいなことを言うので、設定ファイルの場所を開いて `config.toml` で以下の内容を入力してください。
+
+```
+[Credential]
+  Identifier = "<ここにIdentifierを入れる>"
+  Password = "<ここにパスワードを入れる>"
+  Host = "https://bsky.social"
+```
+
+以上
 
 ### ラーメン大陸リスペクト機能
 チェックが付いた機能は実装済み(つまりまだなにもできていない)

--- a/app.go
+++ b/app.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"strings"
 	"net/http"
 	"time"
 
-	// cliutil "github.com/bluesky-social/indigo/cmd/gosky/util"
 	"github.com/adrg/xdg"
 	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 // App struct
@@ -21,6 +22,19 @@ type App struct {
 	ctx    context.Context
 	xrpcc  *xrpc.Client
 	logger *log.Logger
+}
+
+// dialogResults is used for casting Dialog's response to boolean. Note that keys are lowercase.
+var dialogResults = map[string]bool{
+	"ok":        true,
+	"cancel":    false,
+	"abort":     false,
+	"retry":     false,
+	"ignore":    false,
+	"yes":       true,
+	"no":        false,
+	"try again": false,
+	"continue":  false,
 }
 
 // NewApp creates a new App application struct
@@ -36,10 +50,45 @@ func (a *App) startup(ctx context.Context) {
 	var auth *xrpc.AuthInfo
 
 	cred := a.config.Credential
+	if cred.Host == "" || cred.Identifier == "" || cred.Password == "" {
+		a.logger.Println("Credentials not set!")
+		result, err := runtime.MessageDialog(a.ctx, runtime.MessageDialogOptions{
+			Type:          runtime.QuestionDialog,
+			Title:         "認証情報がないよ",
+			Message:       "config.tomlにIDとパスワードを入力してね。\nこのまま沈没するけど、設定ファイルの場所を開く？",
+			DefaultButton: "Yes",
+		})
+		if err != nil {
+			a.logger.Fatalln("Error creds not set dialog: ", err)
+		}
+		a.logger.Println(result)
+		if dialogResults[strings.ToLower(result)] {
+			a.OpenConfigDirectory()
+		}
+		a.logger.Fatalln("Missing credentials")
+	}
+
 	auth, err := createSession(cred.Host, cred.Identifier, cred.Password)
 
 	if err != nil {
+		// If auth failed,
+		result, err := runtime.MessageDialog(a.ctx, runtime.MessageDialogOptions{
+			Type:          runtime.QuestionDialog,
+			Title:         "認証に失敗しました",
+			Message:       fmt.Sprintf("%sへの認証に失敗しました。\nIDとパスワードを確認してください。\nこのまま沈没するけど、設定ファイルの場所を開く？", cred.Host),
+			DefaultButton: "Yes",
+		})
+
+		if err != nil {
+			a.logger.Fatalln("Error creds not set dialog: ", err)
+		}
+		a.logger.Println(result)
+		if dialogResults[strings.ToLower(result)] {
+			a.OpenConfigDirectory()
+		}
+
 		a.logger.Fatalf("Failed creating session, bad identifier or password?: %v", err)
+		panic(err)
 	}
 
 	xrpcc := &xrpc.Client{
@@ -100,20 +149,15 @@ func NewHttpClient() *http.Client {
 	}
 }
 
-// Greet returns a greeting for the given name
-func (a *App) Greet(name string) string {
-	return fmt.Sprintf("Hello %s, It's show time and current time is %s!", name, time.Now().Format(time.RFC3339))
-}
-
-
 func (a *App) Post(text string) string {
+	a.logger.Println("Post: ", text)
 	res, err := BskyFeedPost(a.xrpcc, text)
 	if err != nil {
 		errs := fmt.Sprintf("Posting error: %s", err.Error())
 		a.logger.Println(errs)
 		return errs
-
 	}
+	a.logger.Println("Post result: ", res)
 	return res
 }
 
@@ -123,11 +167,13 @@ func (a *App) Chikuwa(text string) string {
 
 func (a *App) OpenConfigDirectory() error {
 	f, _ := xdg.ConfigFile("mazesoba-continent")
+	a.logger.Println("OpenConfigDirectory: ", f)
 	return openDirectory(f)
 }
 
 func (a *App) OpenLogDirectory() error {
 	f, _ := xdg.CacheFile("mazesoba-continent")
+	a.logger.Println("OpenLogDirectory: ", f)
 	return openDirectory(f)
 }
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -5,8 +5,6 @@ export function Chikuwa(arg1:string):Promise<string>;
 
 export function GetVersion():Promise<string>;
 
-export function Greet(arg1:string):Promise<string>;
-
 export function OpenConfigDirectory():Promise<void>;
 
 export function OpenLogDirectory():Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -10,10 +10,6 @@ export function GetVersion() {
   return window['go']['main']['App']['GetVersion']();
 }
 
-export function Greet(arg1) {
-  return window['go']['main']['App']['Greet'](arg1);
-}
-
 export function OpenConfigDirectory() {
   return window['go']['main']['App']['OpenConfigDirectory']();
 }

--- a/main.go
+++ b/main.go
@@ -7,21 +7,21 @@ import (
 	"os"
 	"time"
 
-	"golang.org/x/exp/slog"
 	"github.com/adrg/xdg"
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 	"github.com/wailsapp/wails/v2/pkg/options/linux"
+	"golang.org/x/exp/slog"
 
-	// "github.com/wailsapp/wails/v2/pkg/options/mac"
+	"github.com/wailsapp/wails/v2/pkg/options/mac"
 	"github.com/wailsapp/wails/v2/pkg/options/windows"
 )
 
 //go:embed all:frontend/dist
 var assets embed.FS
 
-const Version = "v5"
+const Version = "v6"
 
 func main() {
 	// Create an instance of the app structure
@@ -50,7 +50,6 @@ func main() {
 	}
 
 	app.config = config
-	app.logger.Println(app.config)
 
 	// Create application with options
 	err = wails.Run(&options.App{
@@ -87,6 +86,20 @@ func main() {
 			// OnSuspend func(),
 			// OnResume is called when Windows resumes from low power mode
 			// OnResume func(),
+		},
+		Mac: &mac.Options{
+			TitleBar: &mac.TitleBar{
+				// Tekitou
+				TitlebarAppearsTransparent: true,
+				HideTitle:                  false,
+				HideTitleBar:               true,
+				FullSizeContent:            false,
+				UseToolbar:                 false,
+				HideToolbarSeparator:       true,
+			},
+			// Appearance:           mac.NSAppearanceNameDarkAqua,
+			WebviewIsTransparent: true,
+			WindowIsTranslucent:  true,
 		},
 		Linux: &linux.Options{
 			WindowIsTranslucent: true,


### PR DESCRIPTION
# v6

- リンク切れの公式ラーメン大陸へのリンクをやっぱりやめた
- `config.toml` に認証情報がないときや、認証に失敗したとき、 `config.toml` のディレクトリを開くかどうか聞くようにした
- `config.toml` の書き方を書いた
- mac用の設定を公式からコピペした
- v5まではログに設定ファイルの内容を出力してしまっていたが、しないように直した